### PR TITLE
travis: use xvfb-run instead of xvfb

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,14 +42,14 @@ install:
     - docker build -t raz .
 
 script:
-    # Run Docker, build RaZ and, if needed, set the EXPORT environment variable, start the Xvfb server & launch unit tests
+    # Run Docker, build RaZ and, if needed, launch unit tests in a new Xvfb server
     # Xvfb allows to run a program in headless mode (without a screen); this allows GLFW to be initialized properly
     - docker run --name RaZ -w /RaZ -v `pwd`:/RaZ raz
         bash -c "
             cmake -G \"Unix Makefiles\" -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_C_COMPILER=${C_COMPILER} \
                                         -DRAZ_BUILD_EXAMPLES=true -DRAZ_RUN_TESTS=${RUN_TESTS} -DRAZ_USE_FBX=true . &&
             make -j4 &&
-            if [[ ${RUN_TESTS} == true ]]; then export DISPLAY=:1.0 && (Xvfb :1 -screen 0 1280x720x16 &) && ./tests/RaZ_Tests; fi
+            if [[ ${RUN_TESTS} == true ]]; then xvfb-run -a --server-args='-screen 0 1280x720x16' ./tests/RaZ_Tests; fi
         "
 
 #webhooks:


### PR DESCRIPTION
xvfb-run allows a program to be run in a new xvfb server without having to take care of the lifecycle of the involved server.

See there for inspiration and usage:
https://github.com/zestedesavoir/zds-site/pull/5122/files#diff-b67911656ef5d18c4ae36cb6741b7965R37
