### PR TITLE
Add multiplication between quaternion

### DIFF
--- a/include/RaZ/Math/Quaternion.hpp
+++ b/include/RaZ/Math/Quaternion.hpp
@@ -23,6 +23,9 @@ public:
   Quaternion(const Quaternion&) = default;
   Quaternion(Quaternion&&) noexcept = default;
 
+  /// Return a quaternion representing an identity transform
+  static Quaternion<T> identity() { return Quaternion<T>(1.f, 0.f, 0.f, 0.f); }
+
   /// Computes the norm of the quaternion.
   /// Calculating the actual norm requires a square root operation to be involved, which is expensive.
   /// As such, this function should be used if actual length is needed; otherwise, prefer computeSquaredNorm().

--- a/include/RaZ/Math/Quaternion.hpp
+++ b/include/RaZ/Math/Quaternion.hpp
@@ -56,6 +56,8 @@ public:
   /// \return Reference to the moved quaternion.
   Quaternion& operator=(Quaternion&&) noexcept = default;
 
+  Quaternion<T>& operator*=(const Quaternion<T>& right);
+
 private:
   T m_real {};
   Vec3<T> m_complexes {};

--- a/include/RaZ/Math/Quaternion.hpp
+++ b/include/RaZ/Math/Quaternion.hpp
@@ -17,6 +17,7 @@ class Quaternion {
   static_assert(std::is_floating_point_v<T>, "Error: Quaternion's type must be floating point.");
 
 public:
+  Quaternion(T w, T x, T y, T z) : m_real { w }, m_complexes({ x, y, z }) {}
   Quaternion(Radians<T> angle, const Vec3<T>& axis);
   Quaternion(Radians<T> angle, float axisX, float axisY, float axisZ) : Quaternion(angle, Vec3<T>({ axisX, axisY, axisZ })) {}
   Quaternion(const Quaternion&) = default;

--- a/include/RaZ/Math/Quaternion.hpp
+++ b/include/RaZ/Math/Quaternion.hpp
@@ -56,6 +56,7 @@ public:
   /// \return Reference to the moved quaternion.
   Quaternion& operator=(Quaternion&&) noexcept = default;
 
+  Quaternion<T> operator*(const Quaternion<T>& right) const;
   Quaternion<T>& operator*=(const Quaternion<T>& right);
 
 private:

--- a/include/RaZ/Math/Quaternion.inl
+++ b/include/RaZ/Math/Quaternion.inl
@@ -71,4 +71,16 @@ Mat4<T> Quaternion<T>::computeMatrix() const {
                   {           0,           0,           0, 1 }});
 }
 
+template <typename T>
+Quaternion<T>& Quaternion<T>::operator*=(const Quaternion<T>& right) {
+  Quaternion<T> left = *this;
+
+  m_real         = left.m_real * right.m_real - left.m_complexes[0] * right.m_complexes[0] - left.m_complexes[1] * right.m_complexes[1] - left.m_complexes[2] * right.m_complexes[2];
+  m_complexes[0] = left.m_real * right.m_complexes[0] + left.m_complexes[0] * right.m_real + left.m_complexes[1] * right.m_complexes[2] - left.m_complexes[2] * right.m_complexes[1];
+  m_complexes[1] = left.m_real * right.m_complexes[1] + left.m_complexes[1] * right.m_real + left.m_complexes[2] * right.m_complexes[0] - left.m_complexes[0] * right.m_complexes[2];
+  m_complexes[2] = left.m_real * right.m_complexes[2] + left.m_complexes[2] * right.m_real + left.m_complexes[0] * right.m_complexes[1] - left.m_complexes[1] * right.m_complexes[0];
+
+  return *this;
+}
+
 } // namespace Raz

--- a/include/RaZ/Math/Quaternion.inl
+++ b/include/RaZ/Math/Quaternion.inl
@@ -72,6 +72,13 @@ Mat4<T> Quaternion<T>::computeMatrix() const {
 }
 
 template <typename T>
+Quaternion<T> Quaternion<T>::operator*(const Quaternion<T>& right) const {
+  Quaternion<T> left = *this;
+  left *= right;
+  return left;
+}
+
+template <typename T>
 Quaternion<T>& Quaternion<T>::operator*=(const Quaternion<T>& right) {
   Quaternion<T> left = *this;
 

--- a/tests/RaZ/Math/Quaternion.cpp
+++ b/tests/RaZ/Math/Quaternion.cpp
@@ -39,3 +39,36 @@ TEST_CASE("Quaternion matrix computation") {
                                              {   0.333333343f, -0.666666687f,  0.666666627f, 0.f },
                                              {            0.f,           0.f,           0.f, 1.f }}));
 }
+
+TEST_CASE("Quaternion multiplication") {
+  const auto quatUnit = Raz::Quaternionf::identity();
+  const Raz::Quaternionf squareQuatUnit = quatUnit * quatUnit;
+  CHECK(squareQuatUnit.computeMatrix() == quatUnit.computeMatrix());
+
+  const Raz::Quaternionf quatRotx(45.0_deg, Raz::Axis::X);
+  const Raz::Quaternionf mulRotx  = quatRotx * quatRotx.conjugate();
+  CHECK(mulRotx.computeMatrix() == quatUnit.computeMatrix());
+
+  const Raz::Quaternionf quatRoty(45.0_deg, Raz::Axis::Y);
+  const Raz::Quaternionf mulRoty  = quatRoty * quatRoty.conjugate();
+  CHECK(mulRoty.computeMatrix() == quatUnit.computeMatrix());
+
+  const Raz::Quaternionf quatRotz(45.0_deg, Raz::Axis::Z);
+  const Raz::Quaternionf mulRotz  = quatRotz * quatRotz.conjugate();
+  CHECK(mulRotz.computeMatrix() == quatUnit.computeMatrix());
+
+  /* From Wolfram Alpha:
+   * https://www.wolframalpha.com/input/?i=quaternion%280.99619472%2C+0.0871557444%2C+0%2C+0%29+*+quaternion%280.707106769%2C+0.707106769%2C+-1.41421354%2C+3.53553391%29
+   */
+  const Raz::Quaternionf quat12 = quat1 * quat2;
+  CHECK_THAT(quat12.computeNorm(), IsNearlyEqualTo(3.93700385f));
+  const Raz::Mat4f expected = Raz::Mat4f({{ -0.870967627f,  0.112186f,  0.478361f, 0.f },
+                                          {  -0.45161289f,   -0.5663f, -0.6894576, 0.f },
+                                          {  0.193548396f, -0.816528f,  0.543894f, 0.f },
+                                          {           0.f,        0.f,        0.f, 1.f }});
+  const Raz::Mat4f result = quat12.computeMatrix();
+
+  for(std::size_t i = 0; i < 16; ++i) {
+    CHECK(result[i] == Approx(expected[i]));
+  }
+}


### PR DESCRIPTION
Using quaternion for composing non-translation transforms is more efficient than matrix composition.

This PR adds the necessary functions. They were written by @Razakhel first and fixed by myself. 