### PR TITLE
Export travis environment variable in docker run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ install:
 script:
     # Run Docker, build RaZ, launch unit tests if asked, and generate code coverage details & upload them to Coveralls if asked
     # Xvfb allows to run a program in headless mode (without a screen); this allows GLFW to be initialized properly
-    - docker run --name RaZ -w /RaZ -v `pwd`:/RaZ raz
+    - docker run --name RaZ -w /RaZ -v `pwd`:/RaZ -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" -e TRAVIS_BRANCH="$TRAVIS_BRANCH" raz
         bash -c "
             mkdir build && cd build &&
             cmake -G \"Unix Makefiles\" -DCMAKE_CXX_COMPILER=${CXX_COMPILER} -DCMAKE_C_COMPILER=${C_COMPILER} -DCMAKE_BUILD_TYPE=Debug \


### PR DESCRIPTION
They are needed for coveralls to determine the correct branch name in
particular.